### PR TITLE
Render example status as HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,11 @@ Renders just the exception details section. Returns `nil` if no exception.
 #### `backtrace_html(**options)`
 Renders just the backtrace section. Returns `nil` if no backtrace.
 
+#### `status_html(**options)`
+Renders just the status section.
+
 #### `render_html(**options)`
-Convenience method that renders all three sections in a standard layout.
+Convenience method that renders all four sections in a standard layout.
 
 ### Class Methods
 

--- a/lib/rspec/html_messages.rb
+++ b/lib/rspec/html_messages.rb
@@ -81,16 +81,28 @@ module Rspec
       render_template("_backtrace")
     end
 
+    def status_html(**options)
+      css_class, message = ""
+      if passed?
+        css_class = "alert-success"
+        message = "This test passed!"
+      else
+        css_class = "alert-danger"
+        message = "The test did not pass."
+      end
+      render_template("_status", css_class: css_class, message: message)
+    end
+
     # Public boolean methods so users can make their own decisions
     def has_output?
       # Don't show output for errors before assertions
       return false if error_before_assertion?
 
-      status == "failed" || has_actual?
+      failed? || has_actual?
     end
 
     def has_failure_message?
-      status == "failed" && !error_before_assertion? && failure_message.present?
+      failed? && !error_before_assertion? && failure_message.present?
     end
 
     def has_exception_details?
@@ -142,6 +154,14 @@ module Rspec
 
     private
 
+    def passed?
+      status == "passed"
+    end
+
+    def failed?
+      !passed?
+    end
+
     def default_options
       {
         force_diffable: FORCE_DIFFABLE_MATCHERS,
@@ -174,7 +194,7 @@ module Rspec
     end
 
     def calculate_failure_message
-      return nil unless status == "failed"
+      return nil unless failed?
 
       message = example.dig("exception", "message")
       return nil unless message
@@ -313,8 +333,6 @@ module Rspec
         "#{exception_class}: #{first_line}"
       end
     end
-
-    private
 
     def validate_example!(example)
       raise ArgumentError, "Example cannot be nil" if example.nil?

--- a/lib/rspec/html_messages.rb
+++ b/lib/rspec/html_messages.rb
@@ -157,9 +157,9 @@ module Rspec
     def passed?
       status == "passed"
     end
-
+    
     def failed?
-      !passed?
+      status == "failed"
     end
 
     def default_options

--- a/lib/rspec/html_messages.rb
+++ b/lib/rspec/html_messages.rb
@@ -82,12 +82,11 @@ module Rspec
     end
 
     def status_html(**options)
-      css_class, message = ""
       if passed?
         css_class = "alert-success"
         message = "This test passed!"
       else
-        css_class = "alert-danger"
+        css_class = "alert-warning"
         message = "The test did not pass."
       end
       render_template("_status", css_class: css_class, message: message)

--- a/lib/rspec/html_messages/templates/_status.html.erb
+++ b/lib/rspec/html_messages/templates/_status.html.erb
@@ -1,0 +1,3 @@
+<div class="alert <%= css_class %>" role="alert">
+  <%= message %>
+</div>

--- a/lib/rspec/html_messages/templates/example.html.erb
+++ b/lib/rspec/html_messages/templates/example.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 
   <% if output_content = output_html(**@options) %>
-    <div>
+    <div class="mt-3">
       <%= output_content %>
     </div>
   <% end %>

--- a/lib/rspec/html_messages/templates/example.html.erb
+++ b/lib/rspec/html_messages/templates/example.html.erb
@@ -1,4 +1,10 @@
 <div class="rspec-html-messages">
+  <% if status_content = status_html(**@options) %>
+    <div>
+      <%= status_content %>
+    </div>
+  <% end %>
+
   <% if output_content = output_html(**@options) %>
     <div>
       <%= output_content %>

--- a/lib/rspec/html_messages/version.rb
+++ b/lib/rspec/html_messages/version.rb
@@ -2,6 +2,6 @@
 
 module Rspec
   class HtmlMessages
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
## Problem

`render_html` doesn't explicitly include the status of the test example. The status is important for understanding the output at a glance.

> we could add another method to rspec-html_messages in addition to render_html, output_html, failure_message_html, and backtrace_html: status_html. This would display a div.alert.alert-success with "The test passed!" or div.alert.alert-warning with "The test did not pass." And render_html could call that above the rest.

## Solution

This PR adds a `status_html` method that renders a styled alert with a status message.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `status_html` method to render test status as HTML alert and integrates it into `render_html`, updating templates and version to 0.2.1.
> 
>   - **Behavior**:
>     - Adds `status_html` method in `html_messages.rb` to render test status as HTML alert.
>     - Integrates `status_html` into `render_html` to display status above other sections in `example.html.erb`.
>   - **Templates**:
>     - Adds `_status.html.erb` for rendering status alerts.
>     - Updates `example.html.erb` to include status content.
>   - **Version**:
>     - Updates version to `0.2.1` in `version.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Frspec-html_messages&utm_source=github&utm_medium=referral)<sup> for ca316b29cdd00973fa5dae5bea07d324cf345e04. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->